### PR TITLE
CloudFormation now supports creating HTTP/2 CloudFront distros

### DIFF
--- a/aws/stack/CloudFrontDistribution.js
+++ b/aws/stack/CloudFrontDistribution.js
@@ -11,6 +11,7 @@ module.exports = {
       Enabled: true,
       DefaultRootObject: 'index.html',
       PriceClass: 'PriceClass_100',
+      HttpVersion: 'http2',
       DefaultCacheBehavior: {
         TargetOriginId: join(['S3-', ref('ProjectName')]),
         ViewerProtocolPolicy: 'redirect-to-https',


### PR DESCRIPTION
Will close #12. Will merge when stack update is successful. 

https://console.aws.amazon.com/cloudformation/home#/stacks?filter=active